### PR TITLE
fixing up the command for the pcap lab 7.6.1

### DIFF
--- a/Ingesters/ingesters.tex
+++ b/Ingesters/ingesters.tex
@@ -1201,7 +1201,7 @@ ingester:
 \begin{Verbatim}[breaklines=true]
 docker run --rm --net gravnet --name pcap -d \
 -e GRAVWELL_CLEARTEXT_TARGETS=gravwell:4023 \
-gravwell:pcap \ /opt/gravwell/bin/gravwell_network_capture
+gravwell:pcap /opt/gravwell/bin/gravwell_network_capture
 \end{Verbatim}
 
 

--- a/dockerfiles/go.mod
+++ b/dockerfiles/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/gravwell/manager/v3 v3.3.12 // indirect
 	github.com/nerdalert/nflow-generator v0.0.0-20220501044009-5cc1c43806c2 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
-	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 // indirect
+	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
 )

--- a/dockerfiles/go.sum
+++ b/dockerfiles/go.sum
@@ -304,6 +304,8 @@ golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 h1:9vYwv7OjYaky/tlAeD7C4oC9E
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 h1:v1W7bwXHsnLLloWYTVEdvGvA7BHMeBYsPcF0GLDxIRs=
 golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 h1:Sx/u41w+OwrInGdEckYmEuU5gHoGSL4QbDz3S9s6j4U=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
There was a floating backslash in the pcap lab command, which caused docker to turn kind of dumb.

the go.mod and go.sum changes are a result of updated sys packages, unrelated to this fix.