### PR TITLE
add some basic mention of preprocessors

### DIFF
--- a/Ingesters/ingesters.tex
+++ b/Ingesters/ingesters.tex
@@ -276,6 +276,67 @@ To force the Listener to only look for timestamps that match the
 RFC3339 specification add \code{Timestamp-Format-Override=RFC3339} to the
 Listener config.
 
+\section{Preprocessors}
+\index{Ingesters!preprocessors}
+
+Sometimes, ingested data needs some additional massaging before being
+sent to the indexer.  Maybe it's JSON data sent over syslog and you
+wish to strip out the syslog headers, or you're getting gzip-compressed
+data from an Apache Kafka stream. Maybe you'd like to be able to route
+entries to different tags based on the contents of the entries. Ingest
+preprocessors make this possible by inserting one or more processing
+steps before the entry is sent up to the indexer.
+
+Before those entries are sent to a Gravwell indexer, they may optionally
+be passed through an arbitrary number of preprocessors.
+Each preprocessor will have the opportunity to modify the entries. The
+preprocessors will always be applied in the same order, meaning you
+could e.g. uncompress the entry's data, then modify the entry tag based
+on the uncompressed data.
+
+Preprocessors are configured in the ingester's config file using the
+\code{Preprocessor} configuration stanza. Each \code{Preprocessor} stanza must declare
+the preprocessor module in use via the \code{Type} configuration parameter,
+followed by the preprocessor's specific configuration parameters. Consider
+the following example for the Simple Relay ingester:
+
+\begin{verbatim}
+[Global]
+Ingester-UUID="e985bc57-8da7-4bd9-aaeb-cc8c7d489b42"
+Ingest-Secret = IngestSecrets
+Connection-Timeout = 0
+Insecure-Skip-TLS-Verify=true
+Cleartext-Backend-target=127.0.0.1:4023 #example of adding a cleartext connection
+Log-Level=INFO
+
+[Listener "default"]
+    Bind-String="0.0.0.0:7777" #we are binding to all interfaces, with TCP implied
+    Tag-Name=default
+    Preprocessor=timestamp
+
+[Listener "syslog"]
+    Bind-String="0.0.0.0:601" # TCP syslog
+    Tag-Name=syslog
+
+[preprocessor "timestamp"]
+    Type = regextimestamp
+    Regex ="(?P<badtimestamp>.+) MSG (?P<goodtimestamp>.+) END"
+    TS-Match-Name=goodtimestamp
+    Timezone-Override=US/Pacific
+\end{verbatim}
+
+This configuration defines two data consumers (Simple Relay calls them ``Listeners'') named ``default'' and ``syslog''. It also defines a preprocessor named ``timestamp''. Note how the ``default'' listener includes the option \code{Preprocessor=timestamp}. This specifies that entries coming from \emph{that} listener on port 7777 should be sent to the ``timestamp'' preprocessor. Because the ``syslog'' listener does not set any \code{Preprocessor} option, entries coming in on port 601 will \emph{not} go through any preprocessors.
+
+The full list of preprocessors, along with complete configuration options for each, is maintained in the Gravwell online documentation.\footnote{\href{https://docs.gravwell.io/\#!ingesters/preprocessors/preprocessors.md}{https://docs.gravwell.io/\#!ingesters/preprocessors/preprocessors.md}} The following is a brief description of some of the more important preprocessors:
+
+\begin{itemize}
+\item \textbf{gzip} - Uncompresses compressed entries.
+\item \textbf{Regex router} - Sets entry tag based on the contents of the entries, using regular expressions to match and extract the contents.
+\item \textbf{Regex timestamp extraction} - Uses regular expressions to extract and parse particularly complicated timestamps in entries.
+\item \textbf{Forwarding} - Forwards a log stream on to another endpoint in addition to ingesting into Gravwell.
+\item \textbf{Gravwell forwarding} - Forwards logs to an additional set of Gravwell indexers, for data duplication.
+\end{itemize}
+
 \section{Simple Relay Ingester}
 \index{Ingesters!simple relay}
 Simple Relay is the go-to ingester for text based data sources that can


### PR DESCRIPTION
closes #60.

I don't want to go too deep into the minutiae of configuring individual preprocessors, but rather direct readers to the online documentation for now.

Given the resources to overhaul the training document a bit, we could perhaps go into more detail.