### PR TITLE
ci: Upload PDF on release, not tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,14 @@
-name: Release
+name: Upload PDF to Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types:
+      - published
 
 jobs:
   training-pdf-builder:
     runs-on: ubuntu-latest
-    name: Build the training PDF and Release
+    name: Build the training PDF and upload to Release
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -30,4 +30,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} gravwell_training_${{ github.ref_name }}.pdf --verify-tag --generate-notes
+          gh release upload ${{ github.ref_name }} gravwell_training_${{ github.ref_name }}.pdf  --clobber


### PR DESCRIPTION
This PR addresses no issue.

I'd written the Release workflow to automatically create a Release AND upload a build PDF to that release when a tag was created.

That does a little too much. It would be more useful to just build the PDF and attach it to the Release once it's published (pre-release or full release,  as long as it's non-draft we'll build and attach a PDF).

This PR proposes modifying `release.yml` to...

- listen for Release events instead of tags
- upload the built PDF to the created release