### PR TITLE
Upgrade nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,13 @@
 let
-  pkgs = import (fetchTarball
-    "https://github.com/NixOS/nixpkgs/archive/a6292e34000dc93d43bccf78338770c1c5ec8a99.tar.gz")
-    { };
+  nixpkgs = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/a0374025a863d007d98e3297f6aa46cc3141c2f0.tar.gz";
+    sha256 = "14c0hqipkcm2iqi5ybjpx4xcvwxjp3sx3rfgb69dv83h0gm1crgn";
+  };
 
-in pkgs.stdenv.mkDerivation {
+  pkgs = import nixpkgs { };
+
+in
+pkgs.stdenv.mkDerivation {
   name = "Gravwell Training";
   src = ./.;
 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue.

We hit a build failure [here](https://github.com/gravwell/training/actions/runs/27717409934/job/81993780449) while trying to release the training stuff for v5.9.1

```
error: hash mismatch importing path '/nix/store/gypp7g48p2fcpjx952i84dhw4ak95npl-lpform-36918-tex';
         specified: sha256:033w5cd8z7r02h4r2p8lha6z81qqvky69a7aiahjpd15smss4wjp
         got:       sha256:1f0v56g28nl5v8pmxg9cf7d8rm3jnb2950dknd613z1nlvqw78fc

...

error: some substitutes for the outputs of derivation '/nix/store/m0lq153g1p1yq0g8jia78cgs3078j5z0-lpform-36918-tex.drv' failed (usually happens due to networking issues); try '--fallback' to build derivation from source
```

I was able to reproduce the same failure locally, so I thought I'd try upgrading to a more recent version of nixpkgs, and now I can build the training without issue.

## This PR proposes...

- Bumping nixpkgs to https://github.com/NixOS/nixpkgs/commit/a0374025a863d007d98e3297f6aa46cc3141c2f0, which is https://github.com/NixOS/nixpkgs/tree/nixos-26.05 at the time of writing
  - The release is ~7 days old, so there's been a good amount of cooldown

## PR Tasks

<!-- Add tasks to this list as needed -->

- ~~e2e and/or unit tests included. If not, please provide an explanation.~~
- **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).
  - `nix-build` it locally

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
